### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stg-app-ci-cd.yaml
+++ b/.github/workflows/stg-app-ci-cd.yaml
@@ -1,6 +1,8 @@
 name: STG - Build & deploy App
 run-name: Build & deploy ASP.NET Core app to az app ${{ github.sha }}
 
+permissions:
+  contents: read
 on:
   workflow_dispatch: {}
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ArtiomLK/WebAppNetCore6/security/code-scanning/1](https://github.com/ArtiomLK/WebAppNetCore6/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow to define the least privileges required for all jobs. Based on the actions used in the workflow:
- `actions/checkout` and `actions/upload-artifact` require `contents: read`.
- `azure/webapps-deploy` does not require additional permissions as it uses secrets for deployment.

We will set `contents: read` as the minimal permissions for the workflow. This ensures that the `GITHUB_TOKEN` has only the necessary permissions to interact with the repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
